### PR TITLE
chore: remove dup `--version` from flag

### DIFF
--- a/Sources/rmtrash/rmtrash.swift
+++ b/Sources/rmtrash/rmtrash.swift
@@ -41,9 +41,6 @@ struct Command: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Verbose mode; explain at all times what is being done.")
     var verbose: Bool = false
 
-    @Flag(name: .long, help: "Display version information, and exit.")
-    var version: Bool = false
-
     @Argument(help: "The files or directories to move to trash.")
     var paths: [String] = []
 


### PR DESCRIPTION
currently, there are two `--version` flags, one from out-of-box `CommandConfiguration`, another is from flag, removing the one in `CommandConfiguration`

```
  --version               Display version information, and exit. # flag
  --version               Show the version. # CommandConfiguration
```

relates to https://github.com/Homebrew/homebrew-core/pull/204432

cc @TBXark 